### PR TITLE
Read error pipe into error file handle

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -76,7 +76,7 @@ function spawn(_command, _args, _options) {
         this.fileHandle = pipe.fileHandleForReading()
         this.fileHandle.waitForDataInBackgroundAndNotify()
 
-        this.errFileHandle = pipe.fileHandleForReading()
+        this.errFileHandle = errPipe.fileHandleForReading()
         this.errFileHandle.waitForDataInBackgroundAndNotify()
 
         this.task = NSTask.alloc().init()


### PR DESCRIPTION
Currently an asynchronous call to the `exec` family doesn't correctly push `stderr`. I'm not sure if this is the reason why, but it's definitely not helping: We set up an error pipe, but then never actually put anything into it and instead put `stderr` into the `stdout` pipe.