### PR TITLE
Remove setImmediate

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -216,7 +216,9 @@ module.exports = function spawn(_command, _args, _options) {
     task.launch()
   } catch (err) {
     fiber.cleanup()
-    result.emit('error', err)
+    setImmediate(function() {
+      result.emit('error', err)
+    })
     return result
   }
 

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -213,7 +213,7 @@ module.exports = function spawn(_command, _args, _options) {
       )
     )
 
-    setImmediate(() => task.launch())
+    task.launch()
   } catch (err) {
     fiber.cleanup()
     result.emit('error', err)


### PR DESCRIPTION
This should address the problem where pid always being equal to 0 
as well as returning currently hidden exception that happen within task launch.
Example exception ` objective-c nativeException: <NSException> Couldn't posix_spawn: error 7,`