### PR TITLE
Fix returning stderr

### DIFF
--- a/lib/spawnSync.js
+++ b/lib/spawnSync.js
@@ -100,7 +100,7 @@ function spawnSync(_command, _args, _options) {
           return null
         }
         if (stderrValue) {
-          return stdoutValue
+          return stderrValue
         }
         data = errPipe.fileHandleForReading().readDataToEndOfFile()
         return handleData(data, options.encoding || 'buffer')


### PR DESCRIPTION
A typo was returning stdout in the place of stderr.